### PR TITLE
chore: deleted timeout:false option

### DIFF
--- a/src/connectors/MongoDBDuplexConnector.ts
+++ b/src/connectors/MongoDBDuplexConnector.ts
@@ -83,7 +83,7 @@ export class MongoDBDuplexConnector extends Validatable implements SourceConnect
             }
 
             const collection = this.db.collection(collection_name);
-            const data_cursor = collection.find<Buffer>({}, { timeout: false, batchSize: this.assource.bulk_read_size }).stream();
+            const data_cursor = collection.find<Buffer>({}, { batchSize: this.assource.bulk_read_size }).stream();
 
             return cursorToObservalbe(data_cursor);
         }).pipe(


### PR DESCRIPTION
No data were been supplied to the pipe other than the metadata. This was happening only for Atlas. The issue happens because setting timeout to false is not supported by Atlas. So deleting that option from cursor solved the issue.