### PR TITLE
feat: atlas free tier connection mode

### DIFF
--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -16,9 +16,14 @@ export interface MongoDBConnection {
    */
   dbname: string;
   /**
-  * The time in milliseconds to attempt a connection before timing out.
-  */
+   * The time in milliseconds to attempt a connection before timing out.
+   */
   connectTimeoutMS?: number;
+
+  /**
+   * Disables cursor timeout property and index version metadata for MongoDB Atlas free tier use.
+   */
+  isAtlasFreeTier?: boolean;
 }
 
 export interface CollectionMetadata {


### PR DESCRIPTION
Disables cursor timeout property and index version metadata for MongoDB Atlas free tier use.

These changes fix the following errors when using with MongoDB Atlas free tier:

- `VError: pack collection: xxxxx failed: noTimeout cursors are disallowed in this atlas tier`

- `MongoError: Index option v is disallowed in createIndexes command in this Atlas tier`